### PR TITLE
Import only what we need from Lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 const caches = {};
 


### PR DESCRIPTION
Importing the function directly means that with current versions of Webpack (which don't fully support tree-shaking), the eventual bundle size is reduced significantly: 103KB, or 21.77KB gzipped.