### PR TITLE
Fix invalidateData not clearing state for functional components

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ export const withApiData = mapPropsToData => WrappedComponent => {
 					[ key ]: {
 						isLoading: true,
 						error:     null,
-						...this.state[ key ],
+						data: null,
 						url: endpoint,
 					},
 				} )


### PR DESCRIPTION
e61358885a4b03f55795cc8db65b4041f4d755ef fixed this issue for connected components, but didn't port the fix to the functional variant.